### PR TITLE
変数等を扱うための準備

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,6 @@ export function App(): JSX.Element {
           justify="space-between"
           shadow="md"
           backgroundColor="gray.50"
-          zIndex={50}
           px={3}
         >
           <Logo />
@@ -97,7 +96,9 @@ export function App(): JSX.Element {
               left={0}
               width="100%"
               height="100%"
-              zIndex={location.pathname === route.path ? 40 : undefined}
+              visibility={
+                location.pathname === route.path ? "visible" : "hidden"
+              }
               backgroundColor="white"
             >
               <route.Component />

--- a/src/commons/blockly.ts
+++ b/src/commons/blockly.ts
@@ -33,13 +33,32 @@ export function useBlocklyWorkspace({
     const workspaceArea = workspaceAreaRef.current;
     if (!workspaceArea) return undefined;
     const workspace = Blockly.inject(workspaceArea, {
-      toolbox: [
-        "<xml>",
-        ...toolboxBlocks.map(
-          (toolboxBlock) => `<block type="${toolboxBlock}"></block>`
-        ),
-        "</xml>",
-      ].join(""),
+      toolbox: {
+        kind: "flyoutToolbox",
+        contents: toolboxBlocks.map((toolboxBlock) => ({
+          kind: "block",
+          type: toolboxBlock,
+        })),
+      },
+      // TODO: 現状のインターフェースだと変数等を扱うのが難しいので categoryToolbox を使うとよい。
+      // kind など一部のプロパティが string literal 型になっていないのが気になるので簡単なラッパーをかぶせたい。
+      // https://developers.google.com/blockly/guides/configure/web/toolbox
+      // 厳密なドキュメントはない。
+      // toolbox: {
+      //   kind: "categoryToolbox",
+      //   contents: [
+      //     {
+      //       kind: "category",
+      //       name: "変数",
+      //       custom: "VARIABLE",
+      //     },
+      //     {
+      //       kind: "category",
+      //       name: "関数",
+      //       custom: "PROCEDURE",
+      //     },
+      //   ],
+      // },
       grid: { spacing: 20, length: 3, colour: "#ccc", snap: true },
       trashcan: true,
       renderer: "thrasos",

--- a/src/global.css
+++ b/src/global.css
@@ -2,7 +2,9 @@ html {
   overflow: hidden;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   width: 100%;
   height: 100%;
 }
@@ -37,4 +39,9 @@ html, body, #root {
 }
 .blocklyFlyoutBackground {
   fill: transparent;
+}
+
+/* https://github.com/chakra-ui/chakra-ui/issues/7555 */
+.blocklyFlyoutScrollbar[display="none"] {
+  display: none;
 }


### PR DESCRIPTION
Blockly の React ラッパー部分のツールボックス定義のインターフェースが `string[]` になっていたが、変数等はどうしてもカテゴリを分けて表示する必要があるため、現状の flyoutToolbox は使えない。

https://developers.google.com/blockly/guides/configure/web/toolbox#formats